### PR TITLE
Add support for deep linking to Appcues SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx cap sync
 <docgen-index>
 
 * [`initialize(...)`](#initialize)
-* [`getVersion()`](#getversion)
+* [`version()`](#version)
 * [`identify(...)`](#identify)
 * [`group(...)`](#group)
 * [`anonymous(...)`](#anonymous)
@@ -22,8 +22,8 @@ npx cap sync
 * [`track(...)`](#track)
 * [`screen(...)`](#screen)
 * [`show(...)`](#show)
-* [`stop()`](#stop)
 * [`debug()`](#debug)
+* [`didHandleURL(...)`](#didhandleurl)
 * [Interfaces](#interfaces)
 
 </docgen-index>
@@ -44,10 +44,10 @@ initialize(options: InitializeOptions) => Promise<void>
 --------------------
 
 
-### getVersion()
+### version()
 
 ```typescript
-getVersion() => Promise<VersionResponse>
+version() => Promise<VersionResponse>
 ```
 
 **Returns:** <code>Promise&lt;<a href="#versionresponse">VersionResponse</a>&gt;</code>
@@ -142,20 +142,26 @@ show(options: ShowOptions) => Promise<void>
 --------------------
 
 
-### stop()
-
-```typescript
-stop() => Promise<void>
-```
-
---------------------
-
-
 ### debug()
 
 ```typescript
 debug() => Promise<void>
 ```
+
+--------------------
+
+
+### didHandleURL(...)
+
+```typescript
+didHandleURL(options: DidHandleURLOptions) => Promise<DidHandleURLResponse>
+```
+
+| Param         | Type                                                                |
+| ------------- | ------------------------------------------------------------------- |
+| **`options`** | <code><a href="#didhandleurloptions">DidHandleURLOptions</a></code> |
+
+**Returns:** <code>Promise&lt;<a href="#didhandleurlresponse">DidHandleURLResponse</a>&gt;</code>
 
 --------------------
 
@@ -234,5 +240,19 @@ An intrinsic object that provides functions to convert JavaScript values to and 
 | Prop               | Type                |
 | ------------------ | ------------------- |
 | **`experienceId`** | <code>string</code> |
+
+
+#### DidHandleURLResponse
+
+| Prop          | Type                 |
+| ------------- | -------------------- |
+| **`handled`** | <code>boolean</code> |
+
+
+#### DidHandleURLOptions
+
+| Prop      | Type                |
+| --------- | ------------------- |
+| **`url`** | <code>string</code> |
 
 </docgen-api>

--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
@@ -1,5 +1,7 @@
 package com.appcues.sdk.capacitor
 
+import android.content.Intent
+import android.net.Uri
 import com.appcues.Appcues
 import com.getcapacitor.JSObject
 import com.getcapacitor.Plugin
@@ -32,7 +34,7 @@ class AppcuesPlugin : Plugin() {
     }
 
     @PluginMethod
-    fun getVersion(call: PluginCall) {
+    fun version(call: PluginCall) {
         call.resolve(
             JSObject().apply {
                 put("version", implementation.version)
@@ -105,9 +107,21 @@ class AppcuesPlugin : Plugin() {
     }
 
     @PluginMethod
-    fun stop(call: PluginCall) {
-        implementation.stop()
-        call.resolve()
+    fun didHandleURL(call: PluginCall) {
+        val url = call.getString("url")
+        val uri = Uri.parse(url)
+        if (activity != null) {
+            val intent = Intent(Intent.ACTION_VIEW)
+            intent.data = uri
+            val handled = implementation.onNewIntent(activity, intent)
+            call.resolve(
+                JSObject().apply {
+                    put("handled", handled)
+                }
+            )
+        } else {
+            call.reject("no-activity", "unable to handle the URL, no current running Activity found")
+        }
     }
 
     private fun PluginCall.getPropertiesMap(): Map<String, Any>? {

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -54,6 +54,7 @@
       }
     },
     "..": {
+      "name": "@appcues/capacitor",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -25,6 +25,7 @@ import './theme/variables.css';
 import { Appcues, AppcuesConfig } from '@appcues/capacitor';
 import SignInPage from './pages/signin/SignInPage';
 import HomePage from './pages/home/HomePage';
+import AppUrlListener from './pages/AppUrlListener';
 
 export default function App() {
   // Ensures that first _real_ render of the app doesn't occur until
@@ -47,9 +48,10 @@ export default function App() {
 
   return (
   <IonApp>
-      <IonReactRouter>
+      <IonReactRouter>    
+      <AppUrlListener></AppUrlListener>    
         {
-          initComplete && <IonRouterOutlet id="main">
+          initComplete &&  <IonRouterOutlet id="main">
             <Route path="/signIn" component={SignInPage} />
             <Route path="/home" component={HomePage} />
             <Redirect exact from="/" to="/signIn" />

--- a/example/src/pages/AppUrlListener.tsx
+++ b/example/src/pages/AppUrlListener.tsx
@@ -1,0 +1,18 @@
+import React, { useEffect } from 'react';
+import { App, URLOpenListenerEvent } from '@capacitor/app';
+import { Appcues } from '@appcues/capacitor';
+
+const AppUrlListener: React.FC<any> = () => {
+    useEffect(() => {
+      App.addListener('appUrlOpen', (event: URLOpenListenerEvent) => {
+        const appcuesDidHandleURL = Appcues.didHandleURL({url: event.url});
+        if (!appcuesDidHandleURL) {
+          // Handle a non-Appcues URL
+        }
+      });
+    }, []);
+  
+    return null;
+  };
+  
+  export default AppUrlListener;

--- a/example/src/pages/signin/SignInPage.tsx
+++ b/example/src/pages/signin/SignInPage.tsx
@@ -11,7 +11,7 @@ export class GlobalVars {
 const SignInPage: React.FC = () => {
   const [ version, setVersion ] = useState<string>('');
 
-  useEffect(() => { Appcues.getVersion().then((response: VersionResponse) => { 
+  useEffect(() => { Appcues.version().then((response: VersionResponse) => { 
     setVersion(response.version)
   })}, []);
 

--- a/ios/Plugin/AppcuesPlugin.m
+++ b/ios/Plugin/AppcuesPlugin.m
@@ -5,7 +5,7 @@
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(AppcuesPlugin, "Appcues",
            CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(getVersion, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(version, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(identify, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(group, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(anonymous, CAPPluginReturnPromise);
@@ -14,5 +14,5 @@ CAP_PLUGIN(AppcuesPlugin, "Appcues",
            CAP_PLUGIN_METHOD(show, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(debug, CAPPluginReturnPromise);
            CAP_PLUGIN_METHOD(reset, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(stop, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(didHandleURL, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/AppcuesPlugin.swift
+++ b/ios/Plugin/AppcuesPlugin.swift
@@ -43,7 +43,7 @@ public class AppcuesPlugin: CAPPlugin {
         call.resolve()
     }
     
-    @objc func getVersion(_ call: CAPPluginCall) {
+    @objc func version(_ call: CAPPluginCall) {
         let version = Appcues.version() as String
     
         call.resolve(["version": version])
@@ -118,8 +118,13 @@ public class AppcuesPlugin: CAPPlugin {
         call.resolve()
     }
     
-    @objc func stop(_ call: CAPPluginCall) {
-        // does nothing on IOS.
-        call.resolve()
+    @objc func didHandleURL(_ call: CAPPluginCall) {
+        guard let implementation = implementation else { return call.reject("Must call initialize") }
+        guard let urlParam = call.getString("url") else { return call.reject("Missing url") }
+        guard let url = URL(string: urlParam) else { return call.reject("Invalid url: \(urlParam)") }
+
+        let handled = implementation.didHandleURL(url)
+    
+        call.resolve(["handled": handled])
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,6 +1,6 @@
 export interface AppcuesPlugin {
   initialize(options: InitializeOptions): Promise<void>;
-  getVersion(): Promise<VersionResponse>;
+  version(): Promise<VersionResponse>;
   identify(options: IdentifyOptions): Promise<void>;
   group(options: GroupOptions): Promise<void>;
   anonymous(options: AnonymousOptions): Promise<void>;
@@ -8,9 +8,8 @@ export interface AppcuesPlugin {
   track(options: TrackOptions): Promise<void>;
   screen(options: ScreenOptions): Promise<void>;
   show(options: ShowOptions): Promise<void>;
-  stop(): Promise<void>;
   debug(): Promise<void>;
-  
+  didHandleURL(options: DidHandleURLOptions): Promise<DidHandleURLResponse>;
 }
 
 export interface InitializeOptions {
@@ -57,4 +56,12 @@ export interface ScreenOptions {
 
 export interface ShowOptions {
   experienceId: string;
+}
+
+export interface DidHandleURLOptions {
+  url: string;
+}
+
+export interface DidHandleURLResponse {
+  handled: boolean;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,7 +1,7 @@
 import { WebPlugin } from '@capacitor/core';
 import { IdentifyOptions, ScreenOptions, ShowOptions } from '.';
 
-import type { AnonymousOptions, AppcuesPlugin, GroupOptions, InitializeOptions, TrackOptions, VersionResponse } from './definitions';
+import type { AnonymousOptions, AppcuesPlugin, DidHandleURLOptions, DidHandleURLResponse, GroupOptions, InitializeOptions, TrackOptions, VersionResponse } from './definitions';
 
 export class AppcuesWeb extends WebPlugin implements AppcuesPlugin {
   async initialize(options: InitializeOptions): Promise<void> {
@@ -11,7 +11,7 @@ export class AppcuesWeb extends WebPlugin implements AppcuesPlugin {
     console.log("config: ", options.config)
   }
 
-  async getVersion(): Promise<VersionResponse> {
+  async version(): Promise<VersionResponse> {
     console.log('Appcues.getVersion()')
     return { version: "0.0.0" }
   }
@@ -44,11 +44,12 @@ export class AppcuesWeb extends WebPlugin implements AppcuesPlugin {
     console.log(`Appcues.reset()`);
   }
 
-  async stop(): Promise<void> {
-    console.log(`Appcues.stop()`);
-  }
-
   async debug(): Promise<void> {
     console.log(`Appcues.debug()`);
+  }
+
+  async didHandleURL(options: DidHandleURLOptions): Promise<DidHandleURLResponse> {
+    console.log(`Appcues.didHandleURL(url: ${options.url})`);
+    return { handled: true }
   }
 }


### PR DESCRIPTION
This adds the standard support in our wrapper layer for `didHandleURL(url)` - passing the URL through to the native SDK to see if it's an Appcues deep link, and processing if so.

Setting up link handling in Ionic is fairly simple, and the guide is documented here, for React as an example https://capacitorjs.com/docs/guides/deep-links#react - it just requires a listener added for `appUrlOpen`, then you can get the URL and use as desired.

It requires the standard Info.plist and AndroidManifest.xml configuration in the platform layer, and we can add notes about that in the upcoming doc work in [sc-39437].  The application ID used in those native spots must match the application ID used in the Ionic app js code when initializing the Appcues plugin.

The example app here is updated to demonstrate the plugin calls.  

Testing on an iOS simulator
```
xcrun simctl openurl booted "appcues-{app_id}://sdk/debugger"
```

Testing Android emulator via adb
```
 adb shell am start -W -a android.inadb shell am start -W -a android.intent.action.VIEW -d "appcues-{app_id}://sdk/debugger"
```