### PR TITLE
Improve the plugin API, make config optional, fix config usage on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,22 @@ didHandleURL(options: DidHandleURLOptions) => Promise<DidHandleURLResponse>
 
 #### InitializeOptions
 
-| Prop                | Type                       |
-| ------------------- | -------------------------- |
-| **`accountId`**     | <code>string</code>        |
-| **`applicationId`** | <code>string</code>        |
-| **`config`**        | <code>AppcuesConfig</code> |
+| Prop                | Type                                                    |
+| ------------------- | ------------------------------------------------------- |
+| **`accountId`**     | <code>string</code>                                     |
+| **`applicationId`** | <code>string</code>                                     |
+| **`config`**        | <code><a href="#appcuesconfig">AppcuesConfig</a></code> |
+
+
+#### AppcuesConfig
+
+| Prop                         | Type                 |
+| ---------------------------- | -------------------- |
+| **`logging`**                | <code>boolean</code> |
+| **`apiBasePath`**            | <code>string</code>  |
+| **`sessionTimeout`**         | <code>number</code>  |
+| **`activityStorageMaxSize`** | <code>number</code>  |
+| **`activityStorageMaxAge`**  | <code>number</code>  |
 
 
 #### VersionResponse

--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
@@ -23,33 +23,31 @@ class AppcuesPlugin : Plugin() {
 
     private val mainScope = CoroutineScope(Dispatchers.Main)
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun initialize(call: PluginCall) {
         val accountId = call.getString("accountId")
         val applicationId = call.getString("applicationId")
         if (accountId != null && applicationId != null) {
-            mainScope.launch {
-                implementation = Appcues(context, accountId, applicationId) {
-                    AppcuesPluginConfig(call).applyAppcuesConfig(this)
-                }
-                implementation.analyticsListener = object: AnalyticsListener {
-                    override fun trackedAnalytic(
-                        type: AnalyticType,
-                        value: String?,
-                        properties: Map<String, Any>?,
-                        isInternal: Boolean)
-                    {
-                        val data = JSObject().apply {
-                            put("analytic", type.name)
-                            put("value", value ?: "")
-                            put("properties", formatForListener(properties ?: emptyMap<String, Any>()))
-                            put("isInternal", isInternal)
-                        }
-                        notifyListeners("analytics", data)
-                    }
-                }
-                call.resolve()
+            implementation = Appcues(context, accountId, applicationId) {
+                AppcuesPluginConfig(call).applyAppcuesConfig(this)
             }
+            implementation.analyticsListener = object: AnalyticsListener {
+                override fun trackedAnalytic(
+                    type: AnalyticType,
+                    value: String?,
+                    properties: Map<String, Any>?,
+                    isInternal: Boolean)
+                {
+                    val data = JSObject().apply {
+                        put("analytic", type.name)
+                        put("value", value ?: "")
+                        put("properties", formatForListener(properties ?: emptyMap<String, Any>()))
+                        put("isInternal", isInternal)
+                    }
+                    notifyListeners("analytics", data)
+                }
+            }
+            call.resolve()
         }
     }
 
@@ -88,7 +86,7 @@ class AppcuesPlugin : Plugin() {
         )
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun identify(call: PluginCall) {
         val userId = call.getString("userId")
         if (userId != null) {
@@ -97,20 +95,20 @@ class AppcuesPlugin : Plugin() {
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun group(call: PluginCall) {
         val groupId = call.getString("groupId")
         implementation.group(groupId, call.getPropertiesMap())
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun anonymous(call: PluginCall) {
         implementation.anonymous(call.getPropertiesMap())
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun screen(call: PluginCall) {
         val title = call.getString("title")
         if (title != null) {
@@ -119,7 +117,7 @@ class AppcuesPlugin : Plugin() {
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun track(call: PluginCall) {
         val name = call.getString("name")
         if (name != null) {
@@ -128,7 +126,7 @@ class AppcuesPlugin : Plugin() {
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun show(call: PluginCall) {
         val experienceId = call.getString("experienceId")
         if (experienceId != null) {
@@ -139,14 +137,14 @@ class AppcuesPlugin : Plugin() {
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun debug(call: PluginCall) {
         implementation.debug(activity)
 
         call.resolve()
     }
 
-    @PluginMethod
+    @PluginMethod(returnType = PluginMethod.RETURN_NONE)
     fun reset(call: PluginCall) {
         implementation.reset()
         call.resolve()

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -22,7 +22,7 @@ import '@ionic/react/css/text-transformation.css';
 /* Theme variables */
 import './theme/variables.css';
 
-import { Appcues, AppcuesConfig } from '@appcues/capacitor';
+import { Appcues } from '@appcues/capacitor';
 import SignInPage from './pages/signin/SignInPage';
 import HomePage from './pages/home/HomePage';
 import AppUrlListener from './pages/AppUrlListener';
@@ -33,17 +33,8 @@ export default function App() {
   const [initComplete, setInitComplete] = useState(false);
 
   useEffect(() => {
-    const initAppcues = async () => {
-      let appcuesConfig =  new AppcuesConfig();
-      appcuesConfig.logging = true;
-
-      await Appcues.initialize({accountId: 'APPCUES_ACCOUNT_ID', applicationId: 'APPCUES_APPLICATION_ID', config: appcuesConfig});
-
+      Appcues.initialize({accountId: 'APPCUES_ACCOUNT_ID', applicationId: 'APPCUES_APPLICATION_ID', config: { logging: true }});
       setInitComplete(true);
-    }
-    
-    initAppcues();
-
   }, []);
 
   return (

--- a/ios/Plugin/AppcuesPlugin.m
+++ b/ios/Plugin/AppcuesPlugin.m
@@ -4,15 +4,15 @@
 // Define the plugin using the CAP_PLUGIN Macro, and
 // each method the plugin supports using the CAP_PLUGIN_METHOD macro.
 CAP_PLUGIN(AppcuesPlugin, "Appcues",
-           CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(initialize, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(version, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(identify, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(group, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(anonymous, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(screen, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(track, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(show, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(debug, CAPPluginReturnPromise);
-           CAP_PLUGIN_METHOD(reset, CAPPluginReturnPromise);
+           CAP_PLUGIN_METHOD(identify, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(group, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(anonymous, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(screen, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(track, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(show, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(debug, CAPPluginReturnNone);
+           CAP_PLUGIN_METHOD(reset, CAPPluginReturnNone);
            CAP_PLUGIN_METHOD(didHandleURL, CAPPluginReturnPromise);
 )

--- a/ios/Plugin/AppcuesPlugin.swift
+++ b/ios/Plugin/AppcuesPlugin.swift
@@ -17,25 +17,27 @@ public class AppcuesPlugin: CAPPlugin {
 
         let config = Appcues.Config(accountID: accountID, applicationID: applicationID)
 
-        if let logging = call.getBool("logging") {
-            config.logging(logging)
-        }
-        
-        if let apiHost = call.getString("apiBasePath"), let url = URL(string: apiHost) {
-            config.apiHost(url)
-        }
-        
-        
-        if let sessionTimeout = call.getInt("sessionTimeout") {
-            config.sessionTimeout(UInt(sessionTimeout))
-        }
+        if let configParams = call.getObject("config") {
 
-        if let activityStorageMaxSize = call.getInt("activityStorageMaxSize") {
-            config.activityStorageMaxSize(UInt(activityStorageMaxSize))
-        }
+            if let logging = configParams["logging"] as? Bool {
+                config.logging(logging)
+            }
 
-        if let activityStorageMaxAge = call.getInt("activityStorageMaxAge") {
-            config.activityStorageMaxAge(UInt(activityStorageMaxAge))
+            if let apiHost = configParams["apiBasePath"] as? String, let url = URL(string: apiHost) {
+                config.apiHost(url)
+            }
+
+            if let sessionTimeout = configParams["sessionTimeout"] as? Int {
+                config.sessionTimeout(UInt(sessionTimeout))
+            }
+
+            if let activityStorageMaxSize = configParams["activityStorageMaxSize"] as? Int {
+                config.activityStorageMaxSize(UInt(activityStorageMaxSize))
+            }
+
+            if let activityStorageMaxAge = configParams["activityStorageMaxAge"] as? Int {
+                config.activityStorageMaxAge(UInt(activityStorageMaxAge))
+            }
         }
 
         let appcues = Appcues(config: config)

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -17,15 +17,15 @@ export interface AppcuesPlugin extends Plugin {
 export interface InitializeOptions {
   accountId: string;
   applicationId: string;
-  config: AppcuesConfig;
+  config?: AppcuesConfig;
 }
 
-export class AppcuesConfig {
-  logging: boolean = false;
-  apiBasePath: string | null = null;
-  sessionTimeout: number | null = null;
-  activityStorageMaxSize: number | null = null;
-  activityStorageMaxAge: number | null = null;
+export interface AppcuesConfig {
+  logging?: boolean;
+  apiBasePath?: string;
+  sessionTimeout?: number;
+  activityStorageMaxSize?: number;
+  activityStorageMaxAge?: number;
 }
 
 export interface VersionResponse {
@@ -38,7 +38,7 @@ export interface IdentifyOptions {
 }
 
 export interface GroupOptions {
-  groupId: string;
+  groupId?: string;
   properties?: object
 }
 


### PR DESCRIPTION
* updated return type several void return calls to match the doc https://capacitorjs.com/docs/plugins/method-types
* made Android init synchronous - no reason it needed to be launched in a separate coroutine as far as I know - allows updating usage to be synchronous and simpler as well
* fixed the `config` option at init to be optional and simplify usage
* fix iOS usage of `config` options, was not using the correct key into the data previously, so always skipping