### PR TITLE
Restore the repository structure in the package.json required for the iOS pod reference to work correctly

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -55,7 +55,7 @@
     },
     "..": {
       "name": "@appcues/capacitor",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/cli": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "ios/Plugin/",
     "AppcuesCapacitor.podspec"
   ],
-  "repository": "https://github.com/appcues/appcues-capacitor-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/appcues/appcues-capacitor-plugin.git"
+  },
   "author": "Appcues <mobile@appcues.com> (https://www.appcues.com)",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
I messed this up previously as I was confused why the `npm publish` wasn't working, apologies.