### PR TITLE
Updates for SDK 1.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     working_directory: ~/project
   ios_compatible:
     macos:
-      xcode: 13.0.0
+      xcode: 14.0.0
     working_directory: ~/project/example/ios/App
     shell: /bin/bash --login -o pipefail
     environment:
@@ -59,13 +59,13 @@ commands:
     steps:
       - restore_cache:
           name: Restore gem cache
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          key: 2-gems-{{ checksum "Gemfile.lock" }}
       - run:
           name: Install gem dependencies
-          command: bundle check || bundle install --path vendor/bundle
+          command: bundle check || bundle install --deployment --path vendor/bundle
       - save_cache:
           name: Save gem cache
-          key: 1-gems-{{ checksum "Gemfile.lock" }}
+          key: 2-gems-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
 

--- a/AppcuesCapacitor.podspec
+++ b/AppcuesCapacitor.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Appcues'
+  s.dependency 'Appcues', '~> 1.1'
   s.swift_version = '5.1'
 end

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ This capacitor is a bridge between the native Appcues SDKs in an Ionic applicati
 
 ## 🚀 Getting Started
 
+### Prerequisites
+
+**Android** - your application's `build.gradle` must have a `compileSdkVersion` of 33+ and `minSdkVersion` of 21+
+```
+android {
+    compileSdkVersion 33
+
+    defaultConfig {
+        minSdkVersion 21
+    }
+}
+```
+
+**iOS** - your application must target iOS 11+ to install the SDK, and iOS 13+ to render Appcues content. Update the iOS project xcodeproj to set the deployment target, if needed. In the application's `Podfile`, include at least this minimum version.
+```rb
+# Podfile
+platform :ios, '11.0'
+```
+
 ### Installation
 
 In your app's root directory, run:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.10'
+    ext.kotlin_version = '1.7.20'
     repositories {
         google()
         mavenCentral()
@@ -21,10 +21,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 32
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 32
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -51,8 +51,8 @@ repositories {
 
 
 dependencies {
-    implementation "com.appcues:appcues:1.0.0"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1"
+    implementation "com.appcues:appcues:1.1.0"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.3"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
@@ -60,6 +60,6 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
-    implementation "androidx.core:core-ktx:1.8.0"
+    implementation "androidx.core:core-ktx:1.9.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }

--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPlugin.kt
@@ -42,39 +42,13 @@ class AppcuesPlugin : Plugin() {
                     val data = JSObject().apply {
                         put("analytic", type.name)
                         put("value", value ?: "")
-                        put("properties", formatForListener(properties ?: emptyMap<String, Any>()))
+                        put("properties", properties ?: emptyMap<String, Any>())
                         put("isInternal", isInternal)
                     }
                     notifyListeners("analytics", data)
                 }
             }
             call.resolve()
-        }
-    }
-
-    private fun formatForListener(values: Map<*, *>): Map<*, *> {
-        return values.mapValues {
-            with(it.value) {
-                when (this) {
-                    // The Android SDK passes dates as a Long Unix timestamp
-                    is Long -> this.toDouble()
-                    is Map<*, *> -> formatForListener(this)
-                    is List<*> -> formatForListener(this)
-                    else -> this
-                }
-            }
-        }
-    }
-
-    private fun formatForListener(values: List<*>): List<*> {
-        return values.map {
-            when (it) {
-                // The Android SDK passes dates as a Long Unix timestamp
-                is Long -> it.toDouble()
-                is Map<*, *> -> formatForListener(it)
-                is List<*> -> formatForListener(it)
-                else -> this
-            }
         }
     }
 

--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
@@ -23,6 +23,8 @@ class AppcuesPluginConfig(call: PluginCall) {
         sessionTimeout?.let { appcuesConfig.sessionTimeout = it }
         activityStorageMaxSize?.let { appcuesConfig.activityStorageMaxSize = it }
         activityStorageMaxAge?.let { appcuesConfig.activityStorageMaxAge = it }
+
+        appcuesConfig.additionalAutoProperties = mapOf("_applicationFramework" to "capacitor")
     }
 
     private fun Boolean?.toLoggingLevel(): LoggingLevel {

--- a/example/android/Gemfile.lock
+++ b/example/android/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   fastlane

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:7.1.3'
         classpath 'com.google.gms:google-services:4.3.13'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/example/android/variables.gradle
+++ b/example/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 22
-    compileSdkVersion = 32
-    targetSdkVersion = 32
+    compileSdkVersion = 33
+    targetSdkVersion = 33
     androidxActivityVersion = '1.4.0'
     androidxAppCompatVersion = '1.5.1'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/example/ios/App/Gemfile
+++ b/example/ios/App/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem "fastlane", '2.210.1'
 gem "cocoapods", '1.11.3'

--- a/example/ios/App/Gemfile.lock
+++ b/example/ios/App/Gemfile.lock
@@ -275,10 +275,11 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   cocoapods (= 1.11.3)
-  fastlane
+  fastlane (= 2.210.1)
 
 BUNDLED WITH
    2.3.18

--- a/example/ios/App/Podfile
+++ b/example/ios/App/Podfile
@@ -26,4 +26,11 @@ end
 
 post_install do |installer|
   assertDeploymentTarget(installer)
+  installer.pods_project.targets.each do |target|
+    if target.respond_to?(:product_type) and target.product_type == "com.apple.product-type.bundle"
+        target.build_configurations.each do |config|
+            config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+        end
+    end
+  end
 end

--- a/ios/Plugin/AppcuesPlugin.swift
+++ b/ios/Plugin/AppcuesPlugin.swift
@@ -40,6 +40,11 @@ public class AppcuesPlugin: CAPPlugin {
             }
         }
 
+        config.additionalAutoProperties([
+            "_applicationFramework": "capacitor"
+            // does not appear to be any way to get the capacitor version in use programmatically
+        ])
+
         let appcues = Appcues(config: config)
         appcues.analyticsDelegate = self
 
@@ -157,49 +162,8 @@ extension AppcuesPlugin: AppcuesAnalyticsDelegate {
                         data: [
                             "analytic": analyticName,
                             "value": value ?? "",
-                            "properties": formatProperties(properties),
+                            "properties": properties ?? [:],
                             "isInternal": isInternal
                         ])
-    }
-
-    /// Map any value types that need to be handled in a custom fashion for cross platform consistency
-    private func formatProperties( _ properties: [String: Any]?) -> [String: Any] {
-        guard var properties = properties else { return [:] }
-
-        properties.forEach { key, value in
-            switch value {
-            case let date as Date:
-                // dates will format ISO8601 by default, but we'll match Android and
-                // format to a double value
-                properties[key] = (date.timeIntervalSince1970 * 1000).rounded()
-            case let dict as [String: Any]:
-                properties[key] = formatProperties(dict)
-            case let arr as [Any]:
-                properties[key] = formatProperties(arr)
-            default:
-                break
-            }
-        }
-
-        return properties
-    }
-
-    private func formatProperties( _ properties: [Any]?) -> [Any] {
-        guard var properties = properties else { return [] }
-
-        properties.enumerated().forEach { index, value in
-            switch value {
-            case let date as Date:
-                properties[index] = (date.timeIntervalSince1970 * 1000).rounded()
-            case let dict as [String: Any]:
-                properties[index] = formatProperties(dict)
-            case let arr as [Any]:
-                properties[index] = formatProperties(arr)
-            default:
-                break
-            }
-        }
-
-        return properties
     }
 }


### PR DESCRIPTION
Updates for the native 1.1 SDK plus related cleanup.

* simplify the analytics listener property formatting since it is handled in the native SDKs now
* add additionalAutoProperties at startup to capture the _applicationFramework
* update android example for target sdk 33 update (Compose 1.3.0)
* update iOS build to XCode 14