### PR TITLE
Use Xcode 14.2 to avoid Cocoapod issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     working_directory: ~/project
   ios_compatible:
     macos:
-      xcode: 14.3.0
+      xcode: 14.2.0
     resource_class: macos.x86.medium.gen2
     working_directory: ~/project/example/ios/App
     shell: /bin/bash --login -o pipefail


### PR DESCRIPTION
Similar to the Flutter issue in https://github.com/appcues/appcues-flutter-plugin/pull/36, [Ionic apps have an issue](https://forum.ionicframework.com/t/attention-xcode-14-3-doesnt-work-building-operations-fail/232239) with publishing iOS builds using Xcode 14.3. 

The root cause appears to be the [same underlying Cocoapods issue](https://github.com/CocoaPods/CocoaPods/pull/11828) with fix coming in 1.12.1. For now, it seems the simplest route is to use Xcode 14.2 until we can update Cocoapods and then retry Xcode 14.3.