### PR TITLE
Update to Xcode 14.3 and Cocoapods 1.12.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ executors:
     working_directory: ~/project
   ios_compatible:
     macos:
-      xcode: 14.2.0
+      xcode: 14.3.0
     resource_class: macos.x86.medium.gen2
     working_directory: ~/project/example/ios/App
     shell: /bin/bash --login -o pipefail

--- a/example/ios/App/Gemfile
+++ b/example/ios/App/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane", '2.210.1'
-gem "cocoapods", '1.11.3'
+gem "cocoapods", '1.12.1'

--- a/example/ios/App/Gemfile.lock
+++ b/example/ios/App/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.7.2)
+    activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -34,15 +34,15 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.1.0)
-    cocoapods (1.11.3)
+    cocoapods (1.12.1)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.3)
+      cocoapods-core (= 1.12.1)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
-      cocoapods-downloader (>= 1.4.0, < 2.0)
+      cocoapods-downloader (>= 1.6.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.4.0, < 2.0)
+      cocoapods-trunk (>= 1.6.0, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
@@ -50,10 +50,10 @@ GEM
       gh_inspector (~> 1.0)
       molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (>= 1.0, < 3.0)
+      ruby-macho (>= 2.3.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.3)
-      activesupport (>= 5.0, < 7)
+    cocoapods-core (1.12.1)
+      activesupport (>= 5.0, < 8)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
@@ -75,7 +75,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.2.0)
+    concurrent-ruby (1.2.2)
     declarative (0.0.20)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
@@ -84,7 +84,7 @@ GEM
     dotenv (2.8.1)
     emoji_regex (3.2.3)
     escape (0.0.4)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     excon (0.92.4)
     faraday (1.10.2)
@@ -201,7 +201,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
     json (2.6.2)
@@ -209,7 +209,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    minitest (5.17.0)
+    minitest (5.18.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -271,7 +271,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby
@@ -281,7 +281,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  cocoapods (= 1.11.3)
+  cocoapods (= 1.12.1)
   fastlane (= 2.210.1)
 
 BUNDLED WITH


### PR DESCRIPTION
It looks like the latest test build in CircleCI built ok with the recent Cocoapods update, correcting the issues noted in this PR https://github.com/appcues/appcues-capacitor-plugin/pull/95

Propose updating to Xcode 14.3 here so all of our projects are on a consistent environment for the 2.0 releases upcoming.