### PR TITLE
Update Java version for upcoming Android SDK update

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,8 +40,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
The Capacitor 5 update already upgraded this project to AGP 8 in https://github.com/appcues/appcues-capacitor-plugin/pull/101

To prepare for upcoming changes in the Android SDK in https://github.com/appcues/appcues-android-sdk/pull/434, the only remaining change needed was to update the plugin to use java version 17.

Without this change, build will fail with
```
Execution failed for task ':appcues-capacitor:compileDebugKotlin'.
> 'compileDebugJavaWithJavac' task (current target is 11) and 'compileDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
```