### PR TITLE
Update Android SDK and related example app build settings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '1.7.20'
+    ext.kotlin_version = '1.9.10'
     repositories {
         google()
         mavenCentral()
@@ -22,10 +22,10 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace "com.appcues.sdk.capacitor"
-    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 33
+    compileSdkVersion project.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : 34
     defaultConfig {
         minSdkVersion project.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : 22
-        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 33
+        targetSdkVersion project.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -40,8 +40,8 @@ android {
         abortOnError false
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 }
 
@@ -52,7 +52,7 @@ repositories {
 
 
 dependencies {
-    implementation "com.appcues:appcues:3.0.1"
+    implementation "com.appcues:appcues:3.0.3-beta01"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2"
     implementation fileTree(dir: 'libs', include: ['*.jar'])

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -21,6 +21,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 

--- a/example/android/variables.gradle
+++ b/example/android/variables.gradle
@@ -1,7 +1,7 @@
 ext {
     minSdkVersion = 22
-    compileSdkVersion = 33
-    targetSdkVersion = 33
+    compileSdkVersion = 34
+    targetSdkVersion = 34
     androidxActivityVersion = '1.7.0'
     androidxAppCompatVersion = '1.6.1'
     androidxCoordinatorLayoutVersion = '1.2.0'

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -57,7 +57,7 @@
     },
     "..": {
       "name": "@appcues/capacitor",
-      "version": "2.1.3",
+      "version": "3.0.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^5.0.0",


### PR DESCRIPTION
These are the updates to the Capacitor plugin project that would be needed to coincide with the core Android SDK changes in https://github.com/appcues/appcues-android-sdk/pull/477

specifically: compiling against SDK 34 (was 33) and updating the Kotlin version.