### PR TITLE
Handle null config in Android plugin initialization

### DIFF
--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
@@ -5,33 +5,25 @@ import com.appcues.LoggingLevel
 import com.getcapacitor.PluginCall
 
 class AppcuesPluginConfig(call: PluginCall) {
-    private val jsObject = call.getObject("config")
-
-    private val loggingLevel: LoggingLevel = jsObject.getBool("logging").toLoggingLevel()
-
-    private val apiBasePath: String? = jsObject.getString("apiBasePath")
-
-    private val sessionTimeout: Int? = jsObject.getInteger("sessionTimeout")
-
-    private val activityStorageMaxSize: Int? = jsObject.getInteger("activityStorageMaxSize")
-
-    private val activityStorageMaxAge: Int? = jsObject.getInteger("activityStorageMaxAge")
+    private val config = call.getObject("config")
 
     fun applyAppcuesConfig(appcuesConfig: AppcuesConfig) {
-        loggingLevel.let { appcuesConfig.loggingLevel = it }
-        apiBasePath?.let { appcuesConfig.apiBasePath = it }
-        sessionTimeout?.let { appcuesConfig.sessionTimeout = it }
-        activityStorageMaxSize?.let { appcuesConfig.activityStorageMaxSize = it }
-        activityStorageMaxAge?.let { appcuesConfig.activityStorageMaxAge = it }
+        config?.let { config ->
+            config.getBool("logging")
+                ?.let { appcuesConfig.loggingLevel = if (it) LoggingLevel.DEBUG else LoggingLevel.NONE }
 
-        appcuesConfig.additionalAutoProperties = mapOf("_applicationFramework" to "capacitor")
-    }
+            config.getString("apiBasePath")
+                ?.let { appcuesConfig.apiBasePath = it }
 
-    private fun Boolean?.toLoggingLevel(): LoggingLevel {
-        return when (this) {
-            true -> LoggingLevel.DEBUG
-            false -> LoggingLevel.NONE
-            null -> LoggingLevel.NONE
+            config.getInteger("sessionTimeout")
+                ?.let { appcuesConfig.sessionTimeout = it }
+
+            config.getInteger("activityStorageMaxSize")
+                ?.let { appcuesConfig.activityStorageMaxSize = it }
+
+            config.getInteger("activityStorageMaxAge")
+                ?.let { appcuesConfig.activityStorageMaxAge = it }
         }
+        appcuesConfig.additionalAutoProperties = mapOf("_applicationFramework" to "capacitor")
     }
 }

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -57,7 +57,7 @@
     },
     "..": {
       "name": "@appcues/capacitor",
-      "version": "3.1.0",
+      "version": "3.1.2",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^5.0.0",


### PR DESCRIPTION
Fix an issue raised through support channels. Our example app uses

```js
Appcues.initialize({accountId: 'APPCUES_ACCOUNT_ID', applicationId: 'APPCUES_APPLICATION_ID', config: { logging: true }});
```

and this works fine, but if you remove the optional `config` param completely:

```js
Appcues.initialize({accountId: 'APPCUES_ACCOUNT_ID', applicationId: 'APPCUES_APPLICATION_ID' });
```

it would lead to a null reference on the Android plugin init, as some code there was not checking for the null value.

reorganized this init code a bit to simplify - do the null check once, then only apply the params within when it is found to be non-null.