### PR TITLE
Add support for settings path configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
       HOMEBREW_NO_AUTO_UPDATE: 1
   android_compatible:
     machine: 
-      image: android:default
+      image: android:2024.11.1
     resource_class: large
     working_directory: ~/project/example/android
 

--- a/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
+++ b/android/src/main/java/com/appcues/sdk/capacitor/AppcuesPluginConfig.kt
@@ -15,6 +15,9 @@ class AppcuesPluginConfig(call: PluginCall) {
             config.getString("apiBasePath")
                 ?.let { appcuesConfig.apiBasePath = it }
 
+            config.getString("settingsHost")
+                ?.let { appcuesConfig.apiSettingsPath = it }
+
             config.getInteger("sessionTimeout")
                 ?.let { appcuesConfig.sessionTimeout = it }
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -57,7 +57,7 @@
     },
     "..": {
       "name": "@appcues/capacitor",
-      "version": "5.0.0-beta.1",
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^6.0.0",

--- a/ios/Plugin/AppcuesPlugin.swift
+++ b/ios/Plugin/AppcuesPlugin.swift
@@ -28,6 +28,10 @@ public class AppcuesPlugin: CAPPlugin {
                 config.apiHost(url)
             }
 
+            if let settingsHost = configParams["settingsHost"] as? String, let url = URL(string: settingsHost) {
+                config.settingsHost(url)
+            }
+
             if let sessionTimeout = configParams["sessionTimeout"] as? Int {
                 config.sessionTimeout(UInt(sessionTimeout))
             }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -114,6 +114,10 @@ export class AppcuesConfig {
    */
   apiBasePath?: string;
   /**
+   * The settings host to be used for Appcues settings requests
+   */
+  settingsHost?: string;
+  /**
    * The timeout value, in seconds, used to determine if a new session is
    * started upon the application returning to the foreground.
    * 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a new `settingsHost` configuration option and wires it through the native SDKs.
> 
> - Adds `settingsHost` to `AppcuesConfig` in `src/definitions.ts`
> - iOS: reads `settingsHost` and applies via `config.settingsHost(url)` in `AppcuesPlugin.swift`
> - Android: reads `settingsHost` and applies via `appcuesConfig.apiSettingsPath` in `AppcuesPluginConfig.kt`
> - CI: updates CircleCI Android machine image to `android:2024.11.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 798d0425ead11f1d8a81f03cddaf98515632008a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->