### PR TITLE
Update native SDK dependencies

### DIFF
--- a/AppcuesCapacitor.podspec
+++ b/AppcuesCapacitor.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'
-  s.dependency 'Appcues', '~> 5.0.0'
+  s.dependency 'Appcues', '~> 5.0.1'
   s.swift_version = '5.1'
 end

--- a/example/ios/App/App/capacitor.config.json
+++ b/example/ios/App/App/capacitor.config.json
@@ -8,6 +8,7 @@
 	},
 	"packageClassList": [
 		"AppcuesPlugin",
+		"Appcues",
 		"ActionSheetPlugin",
 		"AppPlugin",
 		"HapticsPlugin",

--- a/example/ios/App/Podfile
+++ b/example/ios/App/Podfile
@@ -25,7 +25,7 @@ end
 
 target 'AppcuesNotificationServiceExtension' do
   use_frameworks!
-  pod 'AppcuesNotificationService', '5.0.0'
+  pod 'AppcuesNotificationService', '5.0.1'
 end
 
 post_install do |installer|

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -57,7 +57,7 @@
     },
     "..": {
       "name": "@appcues/capacitor",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "devDependencies": {
         "@capacitor/android": "^6.0.0",


### PR DESCRIPTION
iOS 5.0.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update that bumps the iOS Appcues SDK and notification service extension pod to `5.0.1`. Main risk is potential upstream SDK behavior/regression changes after the version bump.
> 
> **Overview**
> Updates the iOS native Appcues dependencies from `5.0.0` to `5.0.1` in `AppcuesCapacitor.podspec` and the example app’s notification service extension `Podfile`.
> 
> Adjusts the example iOS `capacitor.config.json` to include `"Appcues"` in `packageClassList`, and bumps the example `package-lock.json` version to `5.0.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c325d0a873302dd1d05185550553b9443af6fa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->